### PR TITLE
Исправил баг в правиле isDoubleConsonantWithVowels …

### DIFF
--- a/jQuery.WordWrapper.js
+++ b/jQuery.WordWrapper.js
@@ -143,7 +143,7 @@
             var cur = utils.getLetter(pos, arr),
                 next = utils.getLetter(pos + 1, arr),
                 afterNext = utils.getLetter(pos + 2, arr),
-                afterAfterNext = utils.getLetter(pos + 2, arr);
+                afterAfterNext = utils.getLetter(pos + 3, arr);
 
             return (next === afterNext)
                 && utils.isConsonant(next)


### PR DESCRIPTION
…для точного соответствия п.119.7 правил переносов

Поправил, чтобы не вставляло перенос между гласной и двойной согласной. Сейчас там так: http://pix.my/qLAkaNju - и это не соответствует правилу 119.7
